### PR TITLE
Add ConfirmationModal component

### DIFF
--- a/resources/js/components/ConfirmationModal.vue
+++ b/resources/js/components/ConfirmationModal.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { Button } from '@/components/ui/button'
+import { useForwardPropsEmits, type DialogRootEmits, type DialogRootProps } from 'reka-ui'
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger
+} from '@/components/ui/dialog'
+
+const props = defineProps<DialogRootProps>()
+const emits = defineEmits<DialogRootEmits & {(e: 'confirmed'): void; (e: 'not-confirmed'): void }>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+    <Dialog v-bind="forwarded">
+        <DialogTrigger as-child>
+            <slot name="trigger" />
+        </DialogTrigger>
+        <DialogContent class="sm:max-w-md">
+            <DialogHeader>
+                <DialogTitle>
+                    <slot name="title">
+                        Are you sure?
+                    </slot>
+                </DialogTitle>
+                <DialogDescription>
+                    <slot name="description">
+                        This action cannot be undone.
+                    </slot>
+                </DialogDescription>
+            </DialogHeader>
+            <DialogFooter class="flex gap-2 sm:justify-end">
+                <DialogClose as-child>
+                    <Button
+                        variant="outline"
+                        @click="emits('not-confirmed')">
+                        Cancel
+                    </Button>
+                </DialogClose>
+                <DialogClose as-child>
+                    <Button @click="emits('confirmed')">
+                        Confirm
+                    </Button>
+                </DialogClose>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>


### PR DESCRIPTION
## Summary
- add a `ConfirmationModal` Vue component using shadcn dialog primitives
- format and lint the new component

## Testing
- `npx eslint resources/js/components/ConfirmationModal.vue`

------
https://chatgpt.com/codex/tasks/task_e_687b81d21288832a8cf4042fca33a16c