### PR TITLE
Implement user review index

### DIFF
--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Book;
 use Inertia\Inertia;
 use App\Models\Review;
+use App\Http\Resources\ReviewResource;
 use App\Enums\ActivityType;
 use Illuminate\Http\Request;
 use App\Http\Requests\DestroyReviewRequest;
@@ -13,10 +14,15 @@ class ReviewController extends Controller
 {
     public function index(Request $request)
     {
+        $reviews = $request->user()->reviews()
+            ->with(['book.authors', 'book.covers', 'book.ratings', 'user'])
+            ->orderByDesc('created_at')
+            ->get();
+
         return Inertia::render('user/Reviews', [
-            'reviews' => $request->user()->reviews()
-                ->with(['book'])
-                ->orderBy('created_at', 'desc')->get(),
+            'reviews' => ReviewResource::collection($reviews),
+        ])->withMeta([
+            'title' => 'Reviews',
         ]);
     }
 

--- a/resources/js/pages/user/Reviews.vue
+++ b/resources/js/pages/user/Reviews.vue
@@ -1,8 +1,42 @@
 <script setup lang="ts">
 import AppLayout from '@/layouts/AppLayout.vue'
+import PageTitle from '@/components/PageTitle.vue'
+import BookCardHorizontal from '@/components/books/BookCardHorizontal.vue'
+import SingleReview from '@/components/SingleReview.vue'
+import { PropType } from 'vue'
+import { Review } from '@/types/review'
 
 defineOptions({ layout: AppLayout })
+
+const props = defineProps({
+    reviews: {
+        type: Array as PropType<Review[]>,
+        default: () => []
+    }
+})
 </script>
 
 <template>
+    <div>
+        <PageTitle class="mb-4">Your Reviews</PageTitle>
+
+        <ul class="divide-y divide-muted rounded-xl bg-white shadow">
+            <li
+                v-for="review in props.reviews"
+                :key="review.uuid"
+                class="p-4 flex flex-col gap-4 md:flex-row"
+            >
+                <BookCardHorizontal
+                    :book="review.book"
+                    :include-actions="false"
+                    class="md:w-1/3"
+                />
+                <SingleReview
+                    :book="review.book"
+                    :review="review"
+                    class="flex-1"
+                />
+            </li>
+        </ul>
+    </div>
 </template>


### PR DESCRIPTION
## Summary
- load user reviews with book data and metadata
- add reviews listing page that shows each reviewed book and details using `SingleReview`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687bdab18270832a88810879aaf9bc98